### PR TITLE
Prefer .yaml over .toml

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -115,7 +115,7 @@ module Jekyll
       when /\.y(a)?ml/
         SafeYAML.load_file(filename)
       else
-        raise ArgumentError, "No parser for '#{filename}' is available. Use a .toml or .y(a)ml file instead."
+        raise ArgumentError, "No parser for '#{filename}' is available. Use a .y(a)ml or .toml file instead."
       end
     end
 


### PR DESCRIPTION
YAML is mature and already works with Jekyll. This PR recommends YAML as first choice and TOML as second in error messages.

TOML is v0.4.0 and is "changing a lot" [according to its author](https://github.com/toml-lang/toml).

And for the love of god, will somebody please read XKCD 927.